### PR TITLE
MDC updates for handNote/script values

### DIFF
--- a/odd/consolidated-schema.odd
+++ b/odd/consolidated-schema.odd
@@ -4259,11 +4259,8 @@
                                     <valItem ident="estrangela">
                                         <desc>The script of the hand is estrangela</desc>
                                     </valItem>
-                                    <valItem ident="geez">
-                                        <desc>The script of the hand is geez</desc>
-                                    </valItem>
-                                    <valItem ident="geez">
-                                        <desc>The script of the hand is geez</desc>
+                                    <valItem ident="ethiopic">
+                                        <desc>The script of the hand is ethiopic</desc>
                                     </valItem>
                                     <valItem ident="gothicoAntiqua">
                                         <desc>The script of the hand is gothico-antiqua (‘fere-humanistica’,

--- a/odd/consolidated-schema.odd
+++ b/odd/consolidated-schema.odd
@@ -4297,6 +4297,9 @@
                                     <valItem ident="kasmiranagari">
                                         <desc>The script of the hand is kasmiranagari</desc>
                                     </valItem>
+                                    <valItem ident="kurrent">
+                                        <desc>The script of the hand is kurrent</desc>
+                                    </valItem>
                                     <valItem ident="maghribi">
                                         <desc>The script of the hand is maghribi</desc>
                                     </valItem>


### PR DESCRIPTION
Some changes to script values noticed during schema implementation:

* Removed 'geez' (this is a language rather than a script). Replaced with 'ethiopic'.
* Added 'kurrent' - German cursive (Kurrentschrift).