### PR TITLE
Allow mixed elements (e.g. text/hi) for formula

### DIFF
--- a/odd/consolidated-schema.odd
+++ b/odd/consolidated-schema.odd
@@ -3967,11 +3967,13 @@
 
                     <elementSpec module="figures" ident="formula" mode="change">
                         <content>
-                            <rng:choice>
-                                <rng:ref name="mathml.math"/>
-                                <rng:ref name="model.hiLike"/>
-                                <rng:text/>
-                            </rng:choice>
+                            <rng:zeroOrMore>
+                                <rng:choice>
+                                    <rng:ref name="mathml.math"/>
+                                    <rng:ref name="model.hiLike"/>
+                                    <rng:text/>
+                                </rng:choice>
+                            </rng:zeroOrMore>
                         </content>
                     </elementSpec>
 


### PR DESCRIPTION
We want to allow mixed usage of text and ```<hi>``` elements so I'm re-introducing rng:zeroOrMore from the base TEI schema for ```formula```.

This could allow blank formula contents, which might need some further thought.